### PR TITLE
Grid compatible config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,45 @@ build_debug/*
 sandbox/*
 
 # Apple stuff
-*.xcodeproj
 .DS_Store
+
+# Created by https://www.gitignore.io/api/xcode
+# Edit at https://www.gitignore.io/?templates=xcode
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.gitignore.io/api/xcode
 
 # VIM
 *.swp

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_SRCDIR([examples/exMathInterpreter.cpp])
 AC_CONFIG_MACRO_DIR([.buildutils/m4])
 AM_INIT_AUTOMAKE([1.11 -Wall -Werror foreign subdir-objects])
 AM_SILENT_RULES([yes])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([LatAnalyzeConfig.h])
 AM_CONDITIONAL([HAVE_AM_MINOR_LE_11],
                [test `automake --version | grep automake | awk -F '.' '{print $2}'` -le 11])
 # Checks for programs

--- a/lib/includes.hpp
+++ b/lib/includes.hpp
@@ -20,6 +20,6 @@
 #ifndef Latan_includes_hpp_
 #define	Latan_includes_hpp_
 
-#include <config.h>
+#include <LatAnalyzeConfig.h>
 
 #endif // Latan_includes_hpp_


### PR DESCRIPTION
Changed name of config.h so that users of LatAnalyze can also include Grid headers.
Problematic on Mac because by default the filesystem is case insensitive and Grid defines Config.h.
