### PR TITLE
Changed linear model's parameters

### DIFF
--- a/lib/Physics/CorrelatorFitter.cpp
+++ b/lib/Physics/CorrelatorFitter.cpp
@@ -117,7 +117,7 @@ DoubleModel CorrelatorModels::makeLinearModel(void)
 
     mod.setFunction([](const double *x, const double *p)
     {
-        return p[0] + p[1]*x[0];
+        return p[1] + p[0]*x[0];
     }, 1, 2);
 
     return mod;


### PR DESCRIPTION
In makeLinearModel, swapped p[0] -> p[1] such that p[0] is always the effective mass parameter.

This was noticed when --plot flag was called, and the effective mass was plotting the y-intercept value over the data.