### PR TITLE
MathInterpreter: Replace Instruction polymorphism with bytecode

### DIFF
--- a/lib/Core/MathInterpreter.hpp
+++ b/lib/Core/MathInterpreter.hpp
@@ -20,6 +20,8 @@
 #ifndef Latan_MathInterpreter_hpp_
 #define	Latan_MathInterpreter_hpp_
 
+#include <cstdint>
+
 #include <LatAnalyze/Functional/Function.hpp>
 #include <LatAnalyze/Global.hpp>
 #include <LatAnalyze/Core/ParserState.hpp>
@@ -79,108 +81,26 @@ private:
  *                         Instruction classes                                *
  ******************************************************************************/
 // Abstract base
-class Instruction
-{
-public:
-    // destructor
-    virtual ~Instruction(void) = default;
-    // instruction execution
-    virtual void operator()(RunContext &context) const = 0;
-    friend std::ostream & operator<<(std::ostream &out, const Instruction &ins);
-private:
-    virtual void print(std::ostream &out) const = 0;
+
+enum class Instruction : std::uint8_t {
+    ADD,
+    SUB,
+    MUL,
+    DIV,
+    POW,
+    NEG,
+    CONST,
+    POP,
+    LOAD,
+    STORE,
+    CALL,
+    RET,
 };
 
 std::ostream & operator<<(std::ostream &out, const Instruction &ins);
 
 // Instruction container
-typedef std::vector<std::unique_ptr<const Instruction>> Program;
-
-// Push
-class Push: public Instruction
-{
-private:
-    enum class ArgType
-    {
-        Constant = 0,
-        Variable = 1
-    };
-public:
-    //constructors
-    explicit Push(const double val);
-    explicit Push(const unsigned int address, const std::string &name);
-    // instruction execution
-    virtual void operator()(RunContext &context) const;
-private:
-    virtual void print(std::ostream& out) const;
-private:
-    ArgType      type_;
-    double       val_;
-    unsigned int address_;
-    std::string  name_;
-};
-
-// Pop
-class Pop: public Instruction
-{
-public:
-    //constructor
-    explicit Pop(const unsigned int address, const std::string &name);
-    // instruction execution
-    virtual void operator()(RunContext &context) const;
-private:
-    virtual void print(std::ostream& out) const;
-private:
-    unsigned int address_;
-    std::string name_;
-};
-
-// Store
-class Store: public Instruction
-{
-public:
-    //constructor
-    explicit Store(const unsigned int address, const std::string &name);
-    // instruction execution
-    virtual void operator()(RunContext &context) const;
-private:
-    virtual void print(std::ostream& out) const;
-private:
-    unsigned int address_;
-    std::string name_;
-};
-
-// Call function
-class Call: public Instruction
-{
-public:
-    //constructor
-    explicit Call(const unsigned int address, const std::string &name);
-    // instruction execution
-    virtual void operator()(RunContext &context) const;
-private:
-    virtual void print(std::ostream& out) const;
-private:
-    unsigned int address_;
-    std::string name_;
-};
-
-// Floating point operations
-#define DECL_OP(name)\
-class name: public Instruction\
-{\
-public:\
-    virtual void operator()(RunContext &context) const;\
-private:\
-    virtual void print(std::ostream &out) const;\
-}
-
-DECL_OP(Neg);
-DECL_OP(Add);
-DECL_OP(Sub);
-DECL_OP(Mul);
-DECL_OP(Div);
-DECL_OP(Pow);
+typedef std::vector<std::uint8_t> Program;
 
 /******************************************************************************
  *                            Expression node classes                         *


### PR DESCRIPTION
Hi Antonin,

I hope you're keeping well.

This change replaces the `Instruction` class hierarchy with a bytecode-based instruction representation. Instead of an `Instruction` instance, each instruction opcode is specified by a single byte, and instruction arguments are packed into the bytecode array. The arithmetic operations are represented by a single byte, the load, store and call operations are encoded as a byte followed by the variable or function address, and the constant instruction is encoded as a single opcode followed by the double-precision floating point value. I hope this makes sense. If not, [this](http://craftinginterpreters.com/a-virtual-machine.html) should provide a fuller explanation.

Replacing the polymorphic instruction classes with a packed bytecode array increases the locality of reference during execution. After some rough benchmarks I found the improvement was a factor of two, though more performance could be squeezed out through other modifications. For example, the `std::deque` container wrapped by the `std::stack` could be replaced with a `std::vector`.

Let me know what you think.

Best,

Matt